### PR TITLE
提供 githook 支援

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,16 @@
 
 ### 開發工具 SkyPat 先備套件
 #### Ubuntu/Debian 使用者
-`$ sudo apt-get install wget automake autoconf libtool build-essential`
+```
+$ sudo apt-get update
+$ sudo apt-get install wget automake autoconf libtool build-essential
+```
+
+#### Ubuntu/Debian 開發者
+```
+$ sudo apt-get update
+$ sudo apt-get install wget automake autoconf libtool build-essential cppcheck astyle colordiff
+```
 
 #### Fedora/CentOS 使用者
 ```
@@ -27,6 +36,8 @@ $ sudo yum install kernel-devel
 1. 系統呼叫目前只支援 Linux 作業系統。 如果沒有使用到系統呼叫，可以在 CMake 的 `USE_SYSCALL` 設定中停用系統呼叫， 讓非 Linux 作業系統也能執行
  
 2. 在文件方面，本專案以 **台灣正體中文** 為主要使用語言，英文為次要使用語言，其他語言 （例如: 簡體中文）僅能做為參考或翻譯使用。
+
+3. 開發上需要注意，透過 **AStyle** 來做原始程式碼的格式規範（依照 `K&R style`）。運行指令： `astyle --style=kr --indent=spaces=4 --indent-switches --suffix=none --recursive *.c *.h *.hpp` 來對程式碼做格式編排
 
 ## 編譯
 

--- a/README_en.md
+++ b/README_en.md
@@ -12,7 +12,16 @@
 
 ### Developer Tool - SkyPat Prerequisite 
 #### Ubuntu/Debian Users 
-`$ sudo apt-get install wget automake autoconf libtool build-essential`
+```
+$ sudo apt-get update
+$ sudo apt-get install wget automake autoconf libtool build-essential 
+```
+
+#### Ubuntu/Debian Developers
+```
+$ sudo apt-get update
+$ sudo apt-get install wget automake autoconf libtool build-essential cppcheck astyle colordiff
+```
 
 #### Fedora/CentOS Users
 ```
@@ -30,6 +39,8 @@ $ sudo yum install kernel-devel
 2. This project uses **"Taiwan Traditional Chinese"** as primary, English as secondary language in documents.
   
   Other languages (Ex: Simplified Chinese) are only used as references or translations.
+
+3. Developers need to pay attention to the format specification of the original code (according to `K&R style`) through **AStyle**. Run instruction: `astyle --style=kr --indent=spaces=4 --indent-switches --suffix=none --recursive *.c *.h *.hpp` to format the code
 
 ## Build
 

--- a/scripts/install-git-hook
+++ b/scripts/install-git-hook
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if ! test -d .git; then
+    echo "Execute scripts/install-git-hooks in the top-level directory."
+    exit 1
+fi
+
+ln -sf ../../scripts/pre-commit.hook .git/hooks/pre-commit || exit 1
+
+echo "********************************************"
+echo "Git commit hooks are installed successfully."
+echo "********************************************"

--- a/scripts/pre-commit.hook
+++ b/scripts/pre-commit.hook
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+OPTIONS="--style=kr --indent=spaces=4 --indent-switches"
+
+RETURN=0
+ASTYLE=$(which astyle)
+if [ $? -ne 0 ]; then
+    echo "[!] astyle not installed. Unable to check source file format policy." >&2
+    exit 1
+fi
+
+DIFF=$(which colordiff)
+if [ $? -ne 0 ]; then
+    DIFF=diff
+fi
+
+FILES=`git diff --cached --name-only --diff-filter=ACMR | grep -E "\.(c|cpp|h|hpp)$"`
+for FILE in $FILES; do
+    nf=`git checkout-index --temp $FILE | cut -f 1`
+    newfile=`mktemp /tmp/${nf}.XXXXXX` || exit 1
+    $ASTYLE $OPTIONS < $nf > $newfile 2>> /dev/null
+    $DIFF -u -p -B  "${nf}" "${newfile}"
+    r=$?
+    rm "${newfile}"
+    rm "${nf}"
+    if [ $r != 0 ] ; then
+        echo "[!] $FILE does not follow the consistent coding style." >&2
+        RETURN=1
+    fi
+done
+
+if [ $RETURN -eq 1 ]; then
+    echo "" >&2
+    echo "Make sure you have run astyle as the following:" >&2
+    echo "    astyle $OPTIONS --suffix=none $FILE" >&2
+    echo
+fi
+
+exit $RETURN


### PR DESCRIPTION
詳細可以看到根目錄底下 `scripts/` 內的腳本，運行 `./scripts/install-git-hook` 來做安裝 githook，並更新 README 上 `Ubuntu` 開發者的相依性說明（`Fedora/CentOS` 由於手邊沒有機器尚未測試）

另外以下方 astyle command 來整理現有的程式碼 (我個人認為等到現階段的幾個 PR 都做 merge 後再來用這段指令做 format，不然應該會有 conflict 產生)：
```bash
astyle --style=kr --indent=spaces=4 --indent-switches --suffix=none --recursive *.c *.h *.hpp
```