### PR TITLE
fix i32_load8_s unittest

### DIFF
--- a/test/unittests/lib/core/runtime/i32_load8_s_unittest.hpp
+++ b/test/unittests/lib/core/runtime/i32_load8_s_unittest.hpp
@@ -38,7 +38,7 @@ SKYPAT_F(runtime_i32_load8_s, regular)
     }
     // error check
     stack->entries->push(stack->entries, new_i32Value(65540));
-    int ret = runtime_i32_load8_u(stack, memory, offset, 0);
+    int ret = runtime_i32_load8_s(stack, memory, offset, 0);
     EXPECT_EQ(ret, -1);
     // clean datas
     free_MemInst(memory);


### PR DESCRIPTION
修正 `i32_load8_s` unittest 的錯誤檢查