### PR TITLE
Implement f32_abs instruction and unittest

### DIFF
--- a/src/lib/core/runtime/f32_abs.c
+++ b/src/lib/core/runtime/f32_abs.c
@@ -1,6 +1,13 @@
 #include <core/Runtime.h>
+#include <dataTypes/Value.h>
+#include <stdlib.h>
 
 int runtime_f32_abs(Stack* stack)
 {
+    Value* value1 = NULL;
+    stack->entries->pop(stack->entries, (void**)&value1);
+    value1->value.u32 &= 0x7fffffff;
+    value1->type = Value_f32;
+    stack->entries->push(stack->entries, value1);
     return 0;
 }

--- a/src/lib/core/runtime/f32_abs.c
+++ b/src/lib/core/runtime/f32_abs.c
@@ -5,9 +5,9 @@
 int runtime_f32_abs(Stack* stack)
 {
     Value* value1 = NULL;
-    stack->entries->pop(stack->entries, (void**)&value1);
+    pop_Value(stack, &value1);
     value1->value.u32 &= 0x7fffffff;
     value1->type = Value_f32;
-    stack->entries->push(stack->entries, value1);
+    push_Value(stack, value1);
     return 0;
 }

--- a/test/unittests/lib/core/runtime/CMakeLists.txt
+++ b/test/unittests/lib/core/runtime/CMakeLists.txt
@@ -88,6 +88,8 @@ add_runtime_unittest(f32_store_unittest)
 add_runtime_unittest(f64_load_unittest)
 add_runtime_unittest(f64_store_unittest)
 add_runtime_unittest(f32_neg_unittest)
+add_runtime_unittest(f32_abs_unittest)
+
 
 # Parmeric Unittest
 add_runtime_unittest(drop_unittest)

--- a/test/unittests/lib/core/runtime/f32_abs_unittest.hpp
+++ b/test/unittests/lib/core/runtime/f32_abs_unittest.hpp
@@ -8,7 +8,7 @@ extern "C" {
 }
 #undef _Bool
 
-SKYPAT_F(Runtime_f32_neg, negative)
+SKYPAT_F(Runtime_f32_abs, negative)
 {
     // prepare
     Stack* stack = new_Stack();
@@ -28,7 +28,7 @@ SKYPAT_F(Runtime_f32_neg, negative)
     free_Stack(stack);
 }
 
-SKYPAT_F(Runtime_f32_neg, positive)
+SKYPAT_F(Runtime_f32_abs, positive)
 {
     // prepare
     Stack* stack = new_Stack();

--- a/test/unittests/lib/core/runtime/f32_abs_unittest.hpp
+++ b/test/unittests/lib/core/runtime/f32_abs_unittest.hpp
@@ -1,0 +1,51 @@
+
+#include <skypat/skypat.h>
+
+#define _Bool bool
+extern "C" {
+#include <dataTypes/Value.h>
+#include <core/Runtime.h>
+}
+#undef _Bool
+
+SKYPAT_F(Runtime_f32_neg, negative)
+{
+    // prepare
+    Stack* stack = new_Stack();
+    Value *val1 = new_f32Value(5), *val2 = new_f32Value(-3);
+    push_Value(stack, val1);
+    push_Value(stack, val2);
+
+    // run
+    runtime_f32_abs(stack);
+
+    // check
+    Value *check = NULL;
+    pop_Value(stack,&check);
+    EXPECT_EQ(check->value.f32, 3);
+
+    // clean
+    free_Value(check);
+    free_Stack(stack);
+}
+
+SKYPAT_F(Runtime_f32_neg, positive)
+{
+    // prepare
+    Stack* stack = new_Stack();
+    Value *val1 = new_f32Value(5), *val2 = new_f32Value(8);
+    push_Value(stack, val1);
+    push_Value(stack, val2);
+
+    // run
+    runtime_f32_abs(stack);
+
+    // check
+    Value *check = NULL;
+    pop_Value(stack,&check);
+    EXPECT_EQ(check->value.f32, 8);
+
+    // clean
+    free_Value(check);
+    free_Stack(stack);
+}

--- a/test/unittests/lib/core/runtime/f32_abs_unittest.hpp
+++ b/test/unittests/lib/core/runtime/f32_abs_unittest.hpp
@@ -12,9 +12,8 @@ SKYPAT_F(Runtime_f32_neg, negative)
 {
     // prepare
     Stack* stack = new_Stack();
-    Value *val1 = new_f32Value(5), *val2 = new_f32Value(-3);
+    Value *val1 = new_f32Value(-3);
     push_Value(stack, val1);
-    push_Value(stack, val2);
 
     // run
     runtime_f32_abs(stack);
@@ -33,9 +32,8 @@ SKYPAT_F(Runtime_f32_neg, positive)
 {
     // prepare
     Stack* stack = new_Stack();
-    Value *val1 = new_f32Value(5), *val2 = new_f32Value(8);
+    Value *val1 = new_f32Value(8);
     push_Value(stack, val1);
-    push_Value(stack, val2);
 
     // run
     runtime_f32_abs(stack);


### PR DESCRIPTION
Unittest 中`f32`算術指令在  CMakeLists.txt 的位置是參考`f32_neg`，但其他的算術指令好像不是放這，這部分有需要修改嗎?