### PR TITLE
修正 loop 的 contInstr

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,4 @@ jobs:
           sudo docker exec -t wasmvm-ci /bin/bash -c "cd ~/build-cmake && cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../install-cmake .." &&
           sudo docker exec -t wasmvm-ci /bin/bash -c "cd ~/build-cmake && make -j8 install" &&
           sudo docker exec -t wasmvm-ci /bin/bash -c "ldconfig" &&
-          sudo docker exec -t wasmvm-ci /bin/bash -c "cd ~/build-cmake && ctest -V"
+          sudo docker exec -t wasmvm-ci /bin/bash -c "cd ~/build-cmake && ctest"

--- a/src/lib/Executor.c
+++ b/src/lib/Executor.c
@@ -1,5 +1,5 @@
 #include "Executor_.h"
-#include <core/Core.h>
+#include <core/Core_.h>
 
 #include <stdlib.h>
 
@@ -78,7 +78,7 @@ Executor new_Executor()
     pthread_mutex_init(&(executor->mutex), NULL);
     pthread_cond_init(&(executor->cond), NULL);
     executor->status = Executor_Stop;
-    executor->cores = new_vector_p(Core, clean_Core);
+    executor->cores = new_vector_p(struct Core_, clean_Core);
     executor->modules = new_vector_p(ModuleInst, clean_ModuleInst);
     executor->store = new_Store();
     return executor;

--- a/src/lib/core/runtime/loop.c
+++ b/src/lib/core/runtime/loop.c
@@ -6,7 +6,7 @@
 int runtime_loop(Stack stack, ControlInstrInst *control)
 {
     Label label = NULL;
-    label = new_Label(label_get_funcAddr(stack_cur_label(stack)), label_get_instrIndex(stack_cur_label(stack)) + 1, label_get_instrIndex(stack_cur_label(stack)) + 1);
+    label = new_Label(label_get_funcAddr(stack_cur_label(stack)), label_get_instrIndex(stack_cur_label(stack)) + 1, label_get_instrIndex(stack_cur_label(stack)));
     label_set_endInstr(label, control->endAddr);
     label_set_resultTypes(label, control->resultTypes);
     push_Label(stack, label);

--- a/test/unittests/lib/core/runtime/loop_unittest.hpp
+++ b/test/unittests/lib/core/runtime/loop_unittest.hpp
@@ -27,7 +27,7 @@ SKYPAT_F(Runtime_control_if, valid)
     pop_Label(stack, &result);
     EXPECT_EQ(label_get_instrIndex(result), 2);
     EXPECT_EQ(label_get_funcAddr(result), 0);
-    EXPECT_EQ(label_get_contInstr(result), 2);
+    EXPECT_EQ(label_get_contInstr(result), 1);
     EXPECT_EQ(label_get_endInstr(result), 4);
     free(result);
 


### PR DESCRIPTION
loop 的 contInstr 比原本多 1，造成 loop 在第二次之後不會產生 label

現在把 loop 的 contInstr 指到 loop 指令上