### PR TITLE
Fix I64_store align bound and call_indirect encoder argument order

### DIFF
--- a/src/lib/encode/instr.cpp
+++ b/src/lib/encode/instr.cpp
@@ -434,7 +434,7 @@ template<> Section::Stream& Section::Stream::operator<< <WasmInstr>(WasmInstr in
     ONE(Array_get,Array_get) ONE(Array_get_s,Array_get_s)
     ONE(Array_get_u,Array_get_u) ONE(Array_set,Array_set)
     ONE(Array_fill,Array_fill)
-    TWO(Call_indirect,Call_indirect,b,a) TWO(Return_call_indirect,Return_call_indirect,b,a)
+    TWO(Call_indirect,Call_indirect,a,b) TWO(Return_call_indirect,Return_call_indirect,a,b)
     TWO(Table_copy,Table_copy,a,b) TWO(Memory_copy,Memory_copy,a,b)
     TWO(Struct_get,Struct_get,a,b) TWO(Struct_get_s,Struct_get_s,a,b)
     TWO(Struct_get_u,Struct_get_u,a,b) TWO(Struct_set,Struct_set,a,b)

--- a/src/lib/validate/func.cpp
+++ b/src/lib/validate/func.cpp
@@ -488,7 +488,7 @@ template<> void Validate::Validator::operator()<WasmFunc>(const WasmFunc& func){
                         throw Exception::Exception("memory index not found");
                     }
                     if(ins.align > 2){
-                        throw Exception::Exception("align should be 0-1");
+                        throw Exception::Exception("align should be 0-2");
                     }
                     state.pop(ValueType::i64, ValueType::i32);
                     state.push(ValueType::i64);
@@ -499,7 +499,7 @@ template<> void Validate::Validator::operator()<WasmFunc>(const WasmFunc& func){
                         throw Exception::Exception("memory index not found");
                     }
                     if(ins.align > 2){
-                        throw Exception::Exception("align should be 0-1");
+                        throw Exception::Exception("align should be 0-2");
                     }
                     state.pop(ValueType::i64, ValueType::i32);
                     state.push(ValueType::i64);
@@ -574,8 +574,8 @@ template<> void Validate::Validator::operator()<WasmFunc>(const WasmFunc& func){
                     if(ins.memidx >= context.mems.size()){
                         throw Exception::Exception("memory index not found");
                     }
-                    if(ins.align > 2){
-                        throw Exception::Exception("align should be 0-2");
+                    if(ins.align > 3){
+                        throw Exception::Exception("align should be 0-3");
                     }
                     state.pop(ValueType::i64);
                     state.pop(ValueType::i64, ValueType::i32);
@@ -608,7 +608,7 @@ template<> void Validate::Validator::operator()<WasmFunc>(const WasmFunc& func){
                         throw Exception::Exception("memory index not found");
                     }
                     if(ins.align > 2){
-                        throw Exception::Exception("align should be 0-1");
+                        throw Exception::Exception("align should be 0-2");
                     }
                     state.pop(ValueType::i64);
                     state.pop(ValueType::i64, ValueType::i32);


### PR DESCRIPTION
## Summary
- **`I64_store` validator**: bumped align bound from `> 2` to `> 3`. `I64_store` writes 8 bytes, so alignment hints up to 3 are spec-legal — the existing `> 3` on `I64_load`/`F64_store` was the correct pattern. Also corrected stale `"align should be 0-1"` strings on `I64_load32_s/u` and `I64_store32` (their bounds were already right, only the message lied).
- **`Call_indirect` / `Return_call_indirect` encoder**: the `TWO` macro was reconstructing the instruction as `{tw.b, tw.a}`, but `TwoIdx` is `{a=tableidx, b=typeidx}` and the constructor is `Call_indirect(tableidx, typeidx)`. The swap made the encoded binary write fields in reverse spec order — round-tripping any wvmcc-emitted module with `call_indirect` failed with `"table index not found for call_indirect"`. Same line, same bug for `Return_call_indirect`.

## Test plan
- [x] `cmake --build build` clean
- [x] `ctest` — all 14 suites pass
- [ ] Round-trip a module containing `call_indirect` through `wasmvm-as` → decoder → validator
- [ ] Confirm `i64.store align=3` (8-byte aligned) now validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)