### PR TITLE
Fix dangling reference to wasmvm --args vector

### DIFF
--- a/src/exec/wasmvm.cpp
+++ b/src/exec/wasmvm.cpp
@@ -159,9 +159,9 @@ int main(int argc, char const *argv[]){
         wasmvm_args.clear();
         wasmvm_args.push_back(main_module);
         if (args["args"]) {
-            const auto& extra_args = std::get<std::vector<std::string>>(args["args"].value());
+            auto extra_args = std::get<std::vector<std::string>>(args["args"].value());
             for (auto& a : extra_args)
-                wasmvm_args.push_back(a);
+                wasmvm_args.push_back(std::move(a));
         }
         host_modules_instanciate(moduleinsts, store);
         #endif


### PR DESCRIPTION
## Summary
- `args[\"args\"].value()` returns a temporary `std::variant`, so `const auto& extra_args = std::get<std::vector<std::string>>(...)` binds into a temporary that's destroyed at the end of the full-expression. Clang flagged it with `-Wdangling-gsl`. The subsequent range-for over `extra_args` was reading freed memory.
- Fix: take the vector by value, move its elements into `wasmvm_args`.

## Test plan
- [x] `cmake --build build --target wasmvm` — no warnings
- [ ] `wasmvm out.wasm --args foo bar` correctly forwards `foo` and `bar`

🤖 Generated with [Claude Code](https://claude.com/claude-code)