### PR TITLE
fix(cmake): make Release build and install work on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,15 +13,25 @@ set(CMAKE_CXX_STANDARD_REQUIRED 20)
 
 if(MSVC)
   add_compile_options(/bigobj)
+  # MSVC DLLs export nothing without explicit __declspec(dllexport)/.def files,
+  # so no import library is generated and dependents fail to link. Auto-export
+  # all symbols so every SHARED library produces a usable import .lib.
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 endif(MSVC)
 
-# LTO for Release builds
+# LTO for Release builds.
+# Note: MSVC's LTCG (/GL) is incompatible with CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS
+# (above) -- the intermediate LTCG object files carry no readable symbol table,
+# so the auto-generated exports.def comes out empty and the DLL exports nothing.
+# Skip LTO on MSVC; Release still gets /O2.
 include(CheckIPOSupported)
 check_ipo_supported(RESULT LTO_SUPPORTED OUTPUT LTO_OUTPUT)
-if(LTO_SUPPORTED)
+if(LTO_SUPPORTED AND NOT MSVC)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE ON)
     set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELWITHDEBINFO ON)
     message(STATUS "LTO enabled for Release builds")
+elseif(MSVC)
+    message(STATUS "LTO disabled on MSVC (incompatible with auto-exported DLL symbols)")
 else()
     message(STATUS "LTO not supported: ${LTO_OUTPUT}")
 endif()

--- a/src/exec/CMakeLists.txt
+++ b/src/exec/CMakeLists.txt
@@ -1,9 +1,18 @@
+# On Windows the WasmVM DLL exports no data symbols, so executables that touch
+# header-inline statics fail to link against it. Link the static library there;
+# elsewhere link the shared library as before.
+if(WIN32)
+    set(WASMVM_LINK_LIB WasmVM_static)
+else()
+    set(WASMVM_LINK_LIB WasmVM)
+endif()
+
 add_executable(wasmvm-as
     as.cpp
     CommandParser.cpp
 )
 target_link_libraries(wasmvm-as
-    WasmVM
+    ${WASMVM_LINK_LIB}
 )
 
 add_executable(wasmvm-ld
@@ -13,7 +22,7 @@ add_executable(wasmvm-ld
     Archive.cpp
 )
 target_link_libraries(wasmvm-ld
-    WasmVM
+    ${WASMVM_LINK_LIB}
 )
 
 add_executable(readwasm
@@ -21,7 +30,7 @@ add_executable(readwasm
     CommandParser.cpp
 )
 target_link_libraries(readwasm
-    WasmVM
+    ${WASMVM_LINK_LIB}
 )
 
 add_executable(wasmvm-ar
@@ -30,7 +39,7 @@ add_executable(wasmvm-ar
     Archive.cpp
 )
 target_link_libraries(wasmvm-ar
-    WasmVM
+    ${WASMVM_LINK_LIB}
 )
 
 add_executable(wasmvm
@@ -39,7 +48,7 @@ add_executable(wasmvm
     ModuleQueue.cpp
 )
 target_link_libraries(wasmvm
-    WasmVM
+    ${WASMVM_LINK_LIB}
 )
 if(BUILD_HOST_MODULES)
 target_link_libraries(wasmvm

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -20,6 +20,9 @@ target_include_directories(WasmVM_textfmt
     PUBLIC ${CMAKE_CURRENT_LIST_DIR}
 )
 set_property(TARGET WasmVM_textfmt PROPERTY POSITION_INDEPENDENT_CODE 1)
+# PCH is disabled on MSVC: its marker symbols pollute the auto-generated
+# exports.def (CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS) and break the DLL link.
+if(NOT MSVC)
 target_precompile_headers(WasmVM_textfmt PRIVATE
     <variant>
     <string>
@@ -28,6 +31,7 @@ target_precompile_headers(WasmVM_textfmt PRIVATE
     <unordered_map>
     <structures/WasmInstr.hpp>
 )
+endif()
 
 add_library(WasmVM_binfmt OBJECT
     # encode
@@ -58,11 +62,13 @@ add_library(WasmVM_binfmt OBJECT
     decode/data.cpp
 )
 set_property(TARGET WasmVM_binfmt PROPERTY POSITION_INDEPENDENT_CODE 1)
+if(NOT MSVC)
 target_precompile_headers(WasmVM_binfmt PRIVATE
     <variant>
     <vector>
     <structures/WasmInstr.hpp>
 )
+endif()
 
 add_library(WasmVM_src OBJECT
     exception.cpp
@@ -83,12 +89,14 @@ add_library(WasmVM_validate OBJECT
     validate/import.cpp
 )
 set_property(TARGET WasmVM_validate PROPERTY POSITION_INDEPENDENT_CODE 1)
+if(NOT MSVC)
 target_precompile_headers(WasmVM_validate PRIVATE
     <variant>
     <optional>
     <vector>
     <structures/WasmInstr.hpp>
 )
+endif()
 
 add_library(WasmVM_exec OBJECT
     instanciate.cpp
@@ -109,6 +117,7 @@ add_library(WasmVM_exec OBJECT
     invoke/numeric.cpp
 )
 set_property(TARGET WasmVM_exec PROPERTY POSITION_INDEPENDENT_CODE 1)
+if(NOT MSVC)
 target_precompile_headers(WasmVM_exec PRIVATE
     <variant>
     <optional>
@@ -117,6 +126,7 @@ target_precompile_headers(WasmVM_exec PRIVATE
     <structures/WasmInstr.hpp>
     <instances/Stack.hpp>
 )
+endif()
 
 add_library(WasmVM_json OBJECT
     json/json.cpp
@@ -134,7 +144,11 @@ add_library(WasmVM SHARED
 target_link_libraries(WasmVM)
 set_property(TARGET WasmVM PROPERTY POSITION_INDEPENDENT_CODE 1)
 
-if(DEV_BUILD)
+# Build the static library when requested (DEV_BUILD) and always on Windows,
+# where the executables must link it: the WasmVM DLL exports no data symbols
+# (no __declspec(dllimport) in the headers), so MSVC can't resolve header-inline
+# references to DLL-resident statics. Linking the static lib avoids that.
+if(DEV_BUILD OR WIN32)
 add_library(WasmVM_static STATIC
     $<TARGET_OBJECTS:WasmVM_textfmt>
     $<TARGET_OBJECTS:WasmVM_binfmt>
@@ -144,13 +158,22 @@ add_library(WasmVM_static STATIC
     $<TARGET_OBJECTS:WasmVM_json>
 )
 target_link_libraries(WasmVM_static)
-set_property(TARGET WasmVM_static PROPERTY OUTPUT_NAME WasmVM)
+# On Windows a SHARED library's import lib and a STATIC library both use the
+# ".lib" extension, so sharing OUTPUT_NAME "WasmVM" collides. Give the static
+# library a distinct name there; keep "WasmVM" everywhere else.
+if(WIN32)
+    set_property(TARGET WasmVM_static PROPERTY OUTPUT_NAME WasmVM_static)
+else()
+    set_property(TARGET WasmVM_static PROPERTY OUTPUT_NAME WasmVM)
+endif()
 
-install(TARGETS WasmVM_static 
+if(DEV_BUILD)
+install(TARGETS WasmVM_static
     COMPONENT library
     ARCHIVE DESTINATION lib
 )
 endif(DEV_BUILD)
+endif()
 
 install(TARGETS WasmVM
     COMPONENT dll


### PR DESCRIPTION
## What

Fixes a chain of Windows/MSVC-specific build failures that surfaced when
configuring a Release build. All changes are guarded behind `MSVC`/`WIN32`;
non-Windows builds are unchanged.

## Why

On MSVC the project did not build in Release. Each fix exposed the next issue:

- **No import library.** The DLLs had no `__declspec(dllexport)`, so MSVC
  generated no import `.lib` and dependents failed to link. Enabled
  `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`.
- **LTO vs. auto-export.** LTCG (`/GL`) objects carry no readable symbol table,
  so the auto-generated `exports.def` came out empty and the DLL exported
  nothing (an 8 KB stub). Disabled LTO on MSVC; Release still gets `/O2`.
- **PCH vs. auto-export.** Precompiled-header marker symbols polluted the
  generated `exports.def` (`LNK2001: unresolved external symbol __`). Disabled
  PCH on MSVC.
- **Static/import lib name collision.** The static lib's `OUTPUT_NAME WasmVM`
  collided with the shared lib's import lib (`WasmVM.lib` on both). Renamed the
  static lib to `WasmVM_static` on Windows.
- **DLL data symbols can't be imported.** The DLL exports no data symbols
  (e.g. `Exception::Warning::handler`, a header-inline static), which MSVC
  can't import without `dllimport`. Executables now link the static library on
  Windows; the static lib is built unconditionally there (install still gated
  on `DEV_BUILD`).

## Testing

Full Release build links all 125 targets; `WasmVM.dll` is a real 2.2 MB binary
and `wasmvm-as.exe --help` runs correctly (x86 / MSVC 14.39).

## Note for reviewers

`wasmvm.exe` dynamically loads `WasmVM_host.dll`, which installs to `lib/`. On
Windows that directory isn't on the default DLL search path, so a follow-up may
be needed to colocate it with the executable or adjust the install layout.
