### PR TITLE
fix(decode): defined evaluation order for multi-field stream reads

### DIFF
--- a/src/exec/ModuleQueue.cpp
+++ b/src/exec/ModuleQueue.cpp
@@ -38,7 +38,7 @@ ModuleQueue::ModuleQueue(
     std::function<void(std::filesystem::path)> find_deps = [&](std::filesystem::path file_path){
         Node node;
         node.file_path = file_path;
-        std::ifstream istream(file_path);
+        std::ifstream istream(file_path, std::ios::binary | std::ios::in);
         node.module = module_decode(istream);
         if(validate){
             std::optional<Exception::Exception> err = module_validate(node.module);

--- a/src/exec/readwasm.cpp
+++ b/src/exec/readwasm.cpp
@@ -58,8 +58,9 @@ int main(int argc, char const *argv[]){
     }
 
     try {
-        // Decode
-        std::ifstream input_file(input_path);
+        // Decode (binary: a wasm module is a byte stream; text mode would
+        // mangle 0x0d/0x1a bytes on Windows)
+        std::ifstream input_file(input_path, std::ios::binary | std::ios::in);
         WasmModule decoded_module = module_decode(input_file);
         input_file.close();
 

--- a/src/lib/decode/func.cpp
+++ b/src/lib/decode/func.cpp
@@ -20,7 +20,15 @@ Stream& Decode::Code::read(Stream& stream){
             code_end += stream.location();
             // Locals
             for(u32_t local_count = stream.get<u32_t>(); local_count > 0; --local_count){
-                func.locals.insert(func.locals.end(), stream.get<u32_t>(), stream.get<ValueType>());
+                // Read the run length and value type as separate, ordered
+                // statements. The evaluation order of function arguments is
+                // unspecified in C++, so passing both stream.get<>() calls
+                // directly to insert() reads them in an ABI-dependent order and
+                // desyncs the stream on some targets (e.g. x86-64), corrupting
+                // every function that declares locals.
+                u32_t count = stream.get<u32_t>();
+                ValueType type = stream.get<ValueType>();
+                func.locals.insert(func.locals.end(), count, type);
             }
             while(stream.location() < code_end){
                 stream >> func.body.emplace_back();

--- a/src/lib/decode/instr.cpp
+++ b/src/lib/decode/instr.cpp
@@ -28,7 +28,12 @@ using BlockType = std::optional<index_t>;
     case Opcode::I :{ \
         u32_t align = stream.get<u32_t>(); \
         if(align >= 0x40){ \
-            instr = Instr::I(stream.get<u32_t>(), stream.get<u32_t>(), align - 0x40); \
+            /* Read memidx then offset in order: argument evaluation order is \
+               unspecified in C++, so two inline get<>() calls would swap them \
+               on some ABIs (e.g. x86-64). */ \
+            u32_t memidx = stream.get<u32_t>(); \
+            u32_t offset = stream.get<u32_t>(); \
+            instr = Instr::I(memidx, offset, align - 0x40); \
         }else{ \
             instr = Instr::I(0, stream.get<u32_t>(), align); \
         } \
@@ -406,16 +411,24 @@ template<> Stream& Decode::operator>> <WasmInstr>(Stream& stream, WasmInstr& ins
             stream >> ins.valtypes;
             instr = ins;
         }break;
-        case Opcode::Table_copy :
-            instr = Instr::Table_copy(stream.get<index_t>(), stream.get<index_t>());
-        break;
+        case Opcode::Table_copy : {
+            // Read both indices in order (unspecified argument evaluation order
+            // would swap them on some ABIs, e.g. x86-64).
+            index_t dstidx = stream.get<index_t>();
+            index_t srcidx = stream.get<index_t>();
+            instr = Instr::Table_copy(dstidx, srcidx);
+        }break;
         case Opcode::Table_init : {
             index_t elemidx = stream.get<index_t>();
             instr = Instr::Table_init(stream.get<index_t>(), elemidx);
         }break;
-        case Opcode::Memory_copy :
-            instr = Instr::Memory_copy(stream.get<index_t>(), stream.get<index_t>());
-        break;
+        case Opcode::Memory_copy : {
+            // Read both indices in order (unspecified argument evaluation order
+            // would swap them on some ABIs, e.g. x86-64).
+            index_t dstidx = stream.get<index_t>();
+            index_t srcidx = stream.get<index_t>();
+            instr = Instr::Memory_copy(dstidx, srcidx);
+        }break;
         case Opcode::Memory_init : {
             index_t dataidx = stream.get<index_t>();
             instr = Instr::Memory_init(stream.get<index_t>(), dataidx);


### PR DESCRIPTION
## Problem

On x86-64 (GCC and MSVC) the binary decoder rejects **every** module whose functions declare locals, with `invalid value type`; arm64 (clang/gcc) decodes the same modules fine. This makes a freestanding C→wasm toolchain built on this library non-functional on x86-64 while passing on arm64.

## Root cause

`src/lib/decode/func.cpp` decoded a function's locals as:

```cpp
func.locals.insert(func.locals.end(), stream.get<u32_t>(), stream.get<ValueType>());
```

The evaluation order of function arguments is **unspecified** in C++. On x86-64 the `ValueType` is read before the run-length `u32`, so the count and type bytes are consumed in swapped order. That desyncs the section stream and the next byte is misread as a value type — surfacing as `invalid value type`. arm64 happens to evaluate left-to-right, so it reads count-then-type and works.

The same anti-pattern appears in `src/lib/decode/instr.cpp` for the memory load/store immediate macro, `table.copy`, and `memory.copy`. Those read two **same-typed** operands, so they don't desync the stream but silently **swap the values** (e.g. `memory.copy` dst/src) on the same targets. `table.init`/`memory.init` were already written correctly — this change makes the rest match.

## Fix

Read each field into an ordered local before use, so the stream is consumed left-to-right on every ABI.

## Also included (Windows-only)

`readwasm` and `ModuleQueue` opened `.wasm` inputs with a default `std::ifstream` (text mode). On Windows a `0x1A` byte is treated as EOF and CRLF is translated, truncating any module whose bytes contain `0x1A` (e.g. a section length). Opened with `std::ios::binary`, matching the other module readers. (No effect on Linux/macOS.)

## Verification

- Repro: a function with an `f64` local (`44 .. / 01 7c` locals entry) was rejected at byte offset of the valtype with `invalid value type`; fixed build decodes it correctly.
- A downstream linker that decodes `.o` objects failed `decode failed: invalid value type` on an object with f64 locals before the fix and links cleanly after.
- Full WasmVM unit suite (14 tests, incl. `suite_instruction`, `suite_roundtrip`) passes.

Resolves the x86-64 decode failure tracked downstream as wvmcc issue #85.