### PR TITLE
ci(docs): build docs on ubuntu-latest with apt sphinx instead of custom image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,11 +27,11 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    container:
-        image: wasmvm/wasmvm:amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y python3-sphinx ninja-build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - run: mkdir -p build && cd build && cmake -G Ninja -D CMAKE_BUILD_TYPE=Release .. && ninja docs


### PR DESCRIPTION
Follow-up to #275. This `docs.yml` change was on the #275 branch but didn't make it into the merge (the merge's second parent was the previous commit), so master still uses the opaque, unpinned `container: wasmvm/wasmvm:amd64` image. This PR re-lands it cleanly off current master (so it does **not** touch #273's CMake changes).

## Change
Drop the custom container; run on `ubuntu-latest` and `apt-get install -y python3-sphinx ninja-build`.

The docs need only stock Sphinx — `sphinx.ext.mathjax` and the `alabaster` theme both ship with Sphinx (no breathe/doxygen/extra theme). Verified locally: `cmake -G Ninja` + `ninja docs` produces `build/docs/html/index.html`, the exact artifact path the workflow uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)