### PR TITLE
fix(test): copy WasmVM.dll next to test binaries on Windows

### DIFF
--- a/test/parse/CMakeLists.txt
+++ b/test/parse/CMakeLists.txt
@@ -13,9 +13,18 @@ macro(add_test_suite suite_name)
     COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_${suite_name}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/${suite_name}
   )
-  set_property(TEST suite_${suite_name} PROPERTY 
+  set_property(TEST suite_${suite_name} PROPERTY
     ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib"
   )
+  # On Windows the loader searches the executable's own directory for
+  # WasmVM.dll, not src/lib. Copy the DLL next to the test binary so the
+  # suite can launch instead of blocking on a missing-DLL dialog.
+  if(WIN32)
+    add_custom_command(TARGET suite_${suite_name}_target POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        $<TARGET_FILE:WasmVM> $<TARGET_FILE_DIR:suite_${suite_name}_target>
+    )
+  endif()
 endmacro(add_test_suite)
 
 include_directories(


### PR DESCRIPTION
## Problem

The `build-windows` CI job's Test step fails with **all 14 parse suites timing out** (0/14 passed). The suites build fine but each launches and hangs until `ctest --timeout 60` kills it.

**Root cause:** `WasmVM` is a `SHARED` library, so it builds as `WasmVM.dll` on Windows. The test CMake only set `LD_LIBRARY_PATH` for the Linux loader — there was no Windows equivalent. On the Visual Studio multi-config generator the DLL lands in `build/src/lib/Release/` while each test exe is in `build/test/parse/Release/`. The Windows loader searches the exe's own directory, not `src/lib`, so every suite blocked on a missing-`WasmVM.dll` dialog.

This is not a regression — Windows tests have always hung. Before `ctest --timeout 60` was added, the same hang ran until the job's hard limit (an earlier run took **5h54m**); the timeout just made it fail fast and visible.

## Fix

Add a Windows-only `POST_BUILD` step to the `add_test_suite` macro that copies `WasmVM.dll` next to each test binary, where the loader looks first. No-op on Linux/macOS.

Chosen over setting `PATH` in the test `ENVIRONMENT` property, which is itself a semicolon-separated list and would mis-parse a Windows `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)