### PR TITLE
fix(exec): repair broken --no-system and readwasm --start flags

### DIFF
--- a/src/exec/readwasm.cpp
+++ b/src/exec/readwasm.cpp
@@ -122,7 +122,7 @@ int main(int argc, char const *argv[]){
             }
         }
         // Start
-        if(args["export"]){
+        if(args["start"]){
             if(decoded_module.start){
                 std::cout << "  (start " << decoded_module.start.value() << ")" << std::endl;
             }

--- a/src/exec/wasmvm.cpp
+++ b/src/exec/wasmvm.cpp
@@ -141,7 +141,7 @@ int main(int argc, char const *argv[]){
         if(args["no-parent"]){
             check_parent = false;
         }
-        if(!args["no-sysyem"]){
+        if(!args["no-system"]){
             system_path = DEFAULT_MODULE_PATH;
         }
         if(args["force"]){


### PR DESCRIPTION
Two CLI flags in `src/exec` were dead due to a typo / copy-paste bug (found while auditing docs against code in #280).

## Fixes
- **`wasmvm --no-system` / `-ns`** — the system-module-path guard checked `args["no-sysyem"]` (typo) instead of `args["no-system"]`, so the flag never disabled the system module lookup path.
- **`readwasm --start` / `-s`** — the start-section dump was gated on `args["export"]` instead of `args["start"]`, so `--start` printed nothing and `--export` leaked the start section.

Both now match the documented behavior in `docs/programs/vm.rst` and `docs/programs/readwasm.rst`.

## Verification
Built and exercised the real binaries:

- `readwasm --start mod.wasm` → prints `(start 0)`; `readwasm --export mod.wasm` → prints only the export (no longer the start section).
- With `DEFAULT_MODULE_PATH` pointed at a temp dir holding `foo.wasm` and a module importing `"foo"`: the default run resolves it (exit 0), while `wasmvm --no-system` now reports `module 'foo' not found` (exit 255). Before the fix both exited 0.

The existing test harness (`test/parse/*`) only exercises the parser library — it doesn't spawn the CLI binaries or capture stdout — so there's no in-pattern place to add a regression test without new integration infrastructure. Verification was done manually against built binaries.

## Noted separately (not in this PR)
While testing I found the two-character **short aliases** like `-ns` / `-np` don't parse (`CommandParser` treats `-ns` as `-n`), even though the help text/docs advertise them. The long forms work. Flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)