### PR TITLE
fix(exec): match multi-character short option aliases

### DIFF
--- a/src/exec/CommandParser.cpp
+++ b/src/exec/CommandParser.cpp
@@ -188,36 +188,21 @@ CommandParser::CommandParser(int argc, const char* argv[],
                 ++argi;
                 process_option(opt_name, inline_val, argi);
             } else {
-                // Short option cluster: -abc, -oVALUE, -o=VALUE
-                // Process characters left to right. A flag (number==0) is consumed
-                // and the next character starts a new option. A value-taking option
-                // eats the rest of the string (with optional leading '=') or the
-                // next argv.
-                ++argi;
-                for(size_t i = 1; i < arg.size(); ){
-                    std::string short_opt = std::string("-") + arg[i];
-                    std::string resolved = aliases.contains(short_opt) ? aliases[short_opt]
-                                         : optmap.contains(short_opt) ? short_opt : "";
-                    if(resolved.empty()){
-                        std::cerr << COLOR_Error ": unknown option '" << short_opt << "'" << std::endl;
-                        help(program, desc, options);
-                        std::exit(-1);
-                    }
-                    ++i;
-                    if(optmap[resolved].number == 0){
-                        args[resolved].emplace<std::monostate>();
-                    } else {
-                        // Rest of the cluster string is the inline value (strip leading '=')
-                        std::string rest = arg.substr(i);
-                        if(!rest.empty() && rest[0] == '='){
-                            rest = rest.substr(1);
-                        }
-                        auto inline_val = rest.empty() ? std::optional<std::string>{}
-                                                       : std::make_optional(rest);
-                        process_option(resolved, inline_val, argi);
-                        break; // rest of cluster was consumed as value
-                    }
+                // Short option: matched as a whole token so multi-character
+                // aliases like "-ns" work (no getopt-style "-abc" clustering).
+                // A value-taking option consumes the next argv, matching the
+                // documented "-o <file>" form.
+                std::string opt_name = arg;
+                if(aliases.contains(opt_name)){
+                    opt_name = aliases[opt_name];
                 }
+                if(!optmap.contains(opt_name)){
+                    std::cerr << COLOR_Error ": unknown option '" << arg << "'" << std::endl;
+                    help(program, desc, options);
+                    std::exit(-1);
+                }
+                ++argi;
+                process_option(opt_name, std::nullopt, argi);
             }
             continue;
         }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,3 +8,4 @@ add_subdirectory(harness)
 
 # testsuite
 add_subdirectory(parse)
+add_subdirectory(exec)

--- a/test/exec/CMakeLists.txt
+++ b/test/exec/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Tests for the CLI executables' shared helpers (compiled from src/exec).
+macro(add_exec_test_suite suite_name)
+  add_executable(exec_suite_${suite_name}_target
+    ${suite_name}/${suite_name}.cpp
+    ${PROJECT_SOURCE_DIR}/src/exec/CommandParser.cpp
+  )
+  target_include_directories(exec_suite_${suite_name}_target PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/exec
+  )
+  target_link_libraries(exec_suite_${suite_name}_target
+    harness
+    WasmVM
+  )
+  set_target_properties(exec_suite_${suite_name}_target
+    PROPERTIES OUTPUT_NAME test_${suite_name}
+  )
+  add_test(NAME exec_suite_${suite_name}
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test_${suite_name}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/${suite_name}
+  )
+  set_property(TEST exec_suite_${suite_name} PROPERTY
+    ENVIRONMENT "LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/src/lib"
+  )
+endmacro(add_exec_test_suite)
+
+add_exec_test_suite(commandparser)

--- a/test/exec/commandparser/commandparser.cpp
+++ b/test/exec/commandparser/commandparser.cpp
@@ -1,0 +1,75 @@
+// Copyright 2023 Luis Hsu. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include <harness.hpp>
+#include <string>
+
+#include <CommandParser.hpp>
+
+using namespace Testing;
+
+// Option set that mixes a multi-character short alias ("-ns"), single-character
+// flag/value aliases ("-v" / "-o"), and a positional. The buggy cluster-based
+// parser treated "-ns" as the single-char flag "-n" (unknown) and aborted via
+// std::exit, so these positive assertions guard against that regression.
+//
+// argv arrays live at file scope: brace initializers contain commas, which the
+// preprocessor cannot carry through the Test(...) macro. The parser copies what
+// it needs out of the options list during construction, so returning it by
+// value (and letting the initializer_list backing die) is safe.
+static const char* ARGV_SHORT_ALIAS[] = {"prog", "-ns", "main.wasm"};
+static const char* ARGV_LONG_FORM[]   = {"prog", "--no-system", "main.wasm"};
+static const char* ARGV_SINGLE_FLAG[]  = {"prog", "-v", "main.wasm"};
+static const char* ARGV_VALUE_SHORT[]  = {"prog", "-o", "out.wasm", "in.wat"};
+static const char* ARGV_VALUE_EQUALS[] = {"prog", "--output=out.wasm", "in.wat"};
+static const char* ARGV_NONE[]         = {"prog", "main.wasm"};
+
+static CommandParser parse(int argc, const char** argv){
+    return CommandParser(argc, argv, {
+        CommandParser::Optional("--no-system", "Disable system module path", "-ns"),
+        CommandParser::Optional("--version", "Show version", "-v"),
+        CommandParser::Optional("--output", "Output file", 1, "-o"),
+        CommandParser::Fixed("input", "input file", 1),
+    });
+}
+
+Suite commandparser {
+    Test("multi_char_short_alias", {
+        CommandParser args = parse(3, ARGV_SHORT_ALIAS);
+        Expect(args["no-system"].has_value());
+        Expect(!args["version"].has_value());
+        Assert(args["input"].has_value());
+        ExpectEq(std::get<std::string>(args["input"].value()), std::string("main.wasm"));
+    })
+    Test("long_form_matches_alias", {
+        CommandParser args = parse(3, ARGV_LONG_FORM);
+        Expect(args["no-system"].has_value());
+        Assert(args["input"].has_value());
+        ExpectEq(std::get<std::string>(args["input"].value()), std::string("main.wasm"));
+    })
+    Test("single_char_flag", {
+        CommandParser args = parse(3, ARGV_SINGLE_FLAG);
+        Expect(args["version"].has_value());
+        Expect(!args["no-system"].has_value());
+    })
+    Test("value_short_option_consumes_next_arg", {
+        CommandParser args = parse(4, ARGV_VALUE_SHORT);
+        Assert(args["output"].has_value());
+        ExpectEq(std::get<std::string>(args["output"].value()), std::string("out.wasm"));
+        Assert(args["input"].has_value());
+        ExpectEq(std::get<std::string>(args["input"].value()), std::string("in.wat"));
+    })
+    Test("value_long_option_with_equals", {
+        CommandParser args = parse(3, ARGV_VALUE_EQUALS);
+        Assert(args["output"].has_value());
+        ExpectEq(std::get<std::string>(args["output"].value()), std::string("out.wasm"));
+    })
+    Test("absent_option_is_nullopt", {
+        CommandParser args = parse(2, ARGV_NONE);
+        Expect(!args["no-system"].has_value());
+        Expect(!args["output"].has_value());
+        Assert(args["input"].has_value());
+        ExpectEq(std::get<std::string>(args["input"].value()), std::string("main.wasm"));
+    })
+};


### PR DESCRIPTION
`CommandParser` parsed short options as a getopt-style single-character cluster (`-abc` → `-a -b -c`), so a registered **multi-character** alias like `-ns` (`--no-system`) or `-np` (`--no-parent`) was split into `-n` + `-s` and rejected with `unknown option '-n'` — even though the help text and `docs/programs/*.rst` advertise it. The long forms worked.

## Fix
Match each short token as a whole against the alias / option tables, the same way long options are resolved. A value-taking option consumes the next argv (the documented `-o <file>` form).

The dropped behaviors — getopt-style `-abc` clustering and inline `-oVALUE` / `-o=VALUE` — are undocumented, untested, and fundamentally incompatible with the multi-character aliases the project declares. Nothing in the repo (docs, CMake, scripts) uses them.

## Test
Adds a `test/exec` group that compiles `CommandParser.cpp` and drives it through the existing harness (registered as ctest `exec_suite_commandparser`):
- multi-char alias (`-ns`), long-form equivalence (`--no-system`), single-char flag (`-v`), value-taking short option (`-o out.wasm`), `--output=...`, and absent-option cases.
- The `multi_char_short_alias` case **aborts on the old parser** (`std::exit` on the bogus `-n`) and passes on the fixed one, so it guards the regression.

All 15 ctest suites pass.

## Verification
Built and ran the binaries: `wasmvm -ns` / `-np`, `readwasm -t` / `-s` / `-x`, and `wasmvm-as -o <file>` all work; unknown short tokens are rejected as a whole (`unknown option '-zz'`, not `-z`). With #281's runtime fix applied locally, `-ns` produced the same effect as `--no-system`, confirming the alias resolves correctly.

Note: the full runtime effect of `-ns` (disabling the system module path) is delivered by #281; this PR makes the parser accept and resolve the alias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)